### PR TITLE
validation middleware

### DIFF
--- a/src/abantu/middleware/core.clj
+++ b/src/abantu/middleware/core.clj
@@ -10,7 +10,9 @@
             [ring.middleware.json :as ring]
             [ring.middleware.cookies :as cookies]
             [ring.middleware.multipart-params :as multipart-params]
-            [clojure.walk :as walk]))
+            [clojure.walk :as walk]
+            [abantu.util :as util]
+            [clojure.string :as string]))
 
 (defn wrap-ds [handler ds]
   (fn [request]
@@ -66,6 +68,26 @@
     (-> request
         (assoc :query-params (walk/keywordize-keys query-params))
         (handler))))
+
+(defn- validate-param [request [param-type schema]]
+  (let [{:keys [error] :as validated} (-> (cond
+                                            (= param-type :body) (:body request)
+                                            (= param-type :path) (:path-params request)
+                                            (= param-type :query) (:query-params request))
+                                          (util/validate schema))]
+    (->> (when error
+           (str "In " (name param-type) ":\n" error))
+         (assoc validated :error))))
+
+(defn wrap-input-validation [handler openapi-meta]
+  (fn [request]
+    (let [errors (->> (mapv (partial validate-param request) (:parameters openapi-meta))
+                      (filter #(:error %))
+                      (mapv :error))]
+      (if (seq errors)
+        (-> (res/response {:message (string/join "\n" errors)})
+            (res/status 400))
+        (handler request)))))
 
 (defn apply-generic [app & {:keys [ds]}]
   (-> app

--- a/src/abantu/middleware/interface.clj
+++ b/src/abantu/middleware/interface.clj
@@ -1,6 +1,9 @@
 (ns abantu.middleware.interface
   (:require [abantu.middleware.core :as mw]))
 
+(defn apply-validation [app openapi-meta]
+  (mw/wrap-input-validation app openapi-meta))
+
 (defn apply-generic [app & {:keys [ds store js]}]
   (mw/apply-generic app :ds ds :store store :js js))
 

--- a/src/abantu/routes/openapi.clj
+++ b/src/abantu/routes/openapi.clj
@@ -170,9 +170,9 @@
    (sometimes :noun-class :string)
    (sometimes :type :string)])
 
-(def VocabByIdParams [:map [:id :string]])
+(def VocabByIdParams [:map [:id :int]])
 
-(def IdPathParam [:map [:id :string]])
+(def IdPathParam [:map [:id :int]])
 
 (def DeleteVocabResponse
   [:map [:message :string]])

--- a/src/abantu/routes/util.clj
+++ b/src/abantu/routes/util.clj
@@ -6,43 +6,23 @@
             [reitit.coercion.malli :as coercion]
             [abantu.middleware.interface :as mw]
             [malli.util :as mu]
-            [ring.util.response :as res]
-            [abantu.routes.openapi :as api]
-            [clojure.string :as string]))
+            [abantu.routes.openapi :as api]))
 
 (defn- extract-openapi-meta [handler]
   (-> (util/metadata handler)
       (dissoc :arglists :line :column :file :name :ns)))
 
-(defn- validate-param [request [param-type schema]]
-  (let [validated (-> (cond
-                        (= param-type :body) (:body request)
-                        (= param-type :path) (:path-params request)
-                        (= param-type :query) (:query-params request))
-                      (util/validate schema))]
-    (assoc validated :error (str "In " (name param-type) ":\n" (:error validated)))))
-
-(defn validation-wrapped-handler [handler openapi-meta]
-  (fn [request]
-    (let [errors (->> (mapv (partial validate-param request) (:parameters openapi-meta))
-                      (filter #(:error %))
-                      (mapv :error))]
-      (if (seq errors)
-        (-> (res/response {:message (string/join "\n" errors)})
-            (res/status 400))
-        (handler request)))))
-
-(defn- attach-handler [handler openapi-meta]
+(defn- attach-handler [handler validation-mw openapi-meta]
   (cond-> openapi-meta
     (some? (:parameters openapi-meta))
-    (assoc :middleware [[validation-wrapped-handler openapi-meta]]
+    (assoc :middleware [[validation-mw openapi-meta]]
            :responses (merge (:responses openapi-meta)
                              (api/bad-request)))
     true (assoc :handler handler)))
 
-(defn- merge-route-map [acc [method handler]]
+(defn- merge-route-map [validation-mw acc [method handler]]
   (->> (extract-openapi-meta handler)
-       (attach-handler handler)
+       (attach-handler handler validation-mw)
        (assoc {} method)
        (merge acc)))
 
@@ -56,7 +36,7 @@
   [& opts]
   (let [[route-map opts] (apply parse-route-opts opts)]
     (->> (partition 2 opts)
-         (reduce merge-route-map {})
+         (reduce (partial merge-route-map mw/apply-validation) {})
          (merge route-map))))
 
 (defn- resolve-route-map [method]

--- a/src/abantu/routes/util.clj
+++ b/src/abantu/routes/util.clj
@@ -20,7 +20,7 @@
                         (= param-type :path) (:path-params request)
                         (= param-type :query) (:query-params request))
                       (util/validate schema))]
-    (assoc validated :error (str "In " (name param-type) ": " (:error validated)))))
+    (assoc validated :error (str "In " (name param-type) ":\n" (:error validated)))))
 
 (defn validation-wrapped-handler [handler openapi-meta]
   (fn [request]

--- a/src/abantu/routes/util.clj
+++ b/src/abantu/routes/util.clj
@@ -3,15 +3,35 @@
             [reitit.swagger :as swagger]
             [reitit.swagger-ui :as swagger-ui]
             [reitit.openapi :as openapi]
+            [reitit.coercion.malli :as coercion]
             [abantu.middleware.interface :as mw]
-            [malli.util :as mu]))
+            [malli.util :as mu]
+            [ring.util.response :as res]))
 
 (defn- extract-openapi-meta [handler]
   (-> (util/metadata handler)
       (dissoc :arglists :line :column :file :name :ns)))
 
+(defn- validate-param [request [param-type schema]]
+  (-> (cond
+        (= param-type :body) (:body request)
+        (= param-type :path) (:path-params request)
+        (= param-type :query) (:query-params request))
+      (util/validate schema)))
+
 (defn- attach-handler [handler openapi-meta]
-  (assoc openapi-meta :handler handler))
+  (if (some? (:parameters openapi-meta))
+    (assoc openapi-meta
+     :handler
+     (fn [request]
+       (let [errors (->> (mapv (partial validate-param request) (:parameters openapi-meta))
+                         (filter #(:error %))
+                         (mapv :error))]
+         (if (seq errors)
+           (-> (res/response errors)
+               (res/status 400))
+           (handler request)))))
+    (assoc openapi-meta :handler handler)))
 
 (defn- merge-route-map [acc [method handler]]
   (->> (extract-openapi-meta handler)
@@ -23,7 +43,7 @@
   (let [map-first? (map? (first opts))
         route-map (if map-first? (first opts) {})
         opts (if map-first? (rest opts) opts)]
-  [route-map (vec opts)]))
+    [route-map (vec opts)]))
 
 (defn route
   [& opts]
@@ -44,7 +64,6 @@
 (defn get [& opts]
   (apply (resolve-route-map :get) (vec opts)))
 
-
 (defn post [& opts]
   (apply (resolve-route-map :post) (vec opts)))
 
@@ -59,7 +78,6 @@
                                                   :urls.primaryName "swagger"
                                                   :operationsSorter "alpha"}}))
 
-
 (defn swagger-route []
   ["/swagger.json" {:get {:no-doc true
                           :swagger {:info {:title "abantu-api"
@@ -72,7 +90,6 @@
                                                                     :in :header
                                                                     :name "Authorization"}}}
                           :handler (swagger/create-swagger-handler)}}])
-
 
 (defn openapi-route []
   ["/openapi.json" {:get {:no-doc true
@@ -89,7 +106,7 @@
                           :handler (openapi/create-openapi-handler)}}])
 
 (defn data-map [ds]
-  {:data {:coercion (reitit.coercion.malli/create
+  {:data {:coercion (coercion/create
                      {:error-keys #{#_:type :coercion :in :schema :value :errors :humanized #_:transformed}
                       :compile mu/closed-schema
                       :strip-extra-keys true

--- a/src/abantu/routes/util.clj
+++ b/src/abantu/routes/util.clj
@@ -22,15 +22,20 @@
 (defn- attach-handler [handler openapi-meta]
   (if (some? (:parameters openapi-meta))
     (assoc openapi-meta
-     :handler
-     (fn [request]
-       (let [errors (->> (mapv (partial validate-param request) (:parameters openapi-meta))
-                         (filter #(:error %))
-                         (mapv :error))]
-         (if (seq errors)
-           (-> (res/response errors)
-               (res/status 400))
-           (handler request)))))
+           :handler
+           (fn [request]
+             (let [errors (->> (mapv (partial validate-param request) (:parameters openapi-meta))
+                               (filter #(:error %))
+                               (mapv :error))]
+               (if (seq errors)
+                 (-> (res/response errors)
+                     (res/status 400))
+                 (handler request))))
+           :responses (merge (:responses openapi-meta)
+                             {400 {:body [:vector
+                                          [:map
+                                           [:input [:map-of :keyword :any]]
+                                           [:errors [:or [:map-of :keyword [:vector :string]] [:vector :string]]]]]}}))
     (assoc openapi-meta :handler handler)))
 
 (defn- merge-route-map [acc [method handler]]

--- a/src/abantu/routes/util.clj
+++ b/src/abantu/routes/util.clj
@@ -6,37 +6,39 @@
             [reitit.coercion.malli :as coercion]
             [abantu.middleware.interface :as mw]
             [malli.util :as mu]
-            [ring.util.response :as res]))
+            [ring.util.response :as res]
+            [abantu.routes.openapi :as api]
+            [clojure.string :as string]))
 
 (defn- extract-openapi-meta [handler]
   (-> (util/metadata handler)
       (dissoc :arglists :line :column :file :name :ns)))
 
 (defn- validate-param [request [param-type schema]]
-  (-> (cond
-        (= param-type :body) (:body request)
-        (= param-type :path) (:path-params request)
-        (= param-type :query) (:query-params request))
-      (util/validate schema)))
+  (let [validated (-> (cond
+                        (= param-type :body) (:body request)
+                        (= param-type :path) (:path-params request)
+                        (= param-type :query) (:query-params request))
+                      (util/validate schema))]
+    (assoc validated :error (str "In " (name param-type) ": " (:error validated)))))
+
+(defn validation-wrapped-handler [handler openapi-meta]
+  (fn [request]
+    (let [errors (->> (mapv (partial validate-param request) (:parameters openapi-meta))
+                      (filter #(:error %))
+                      (mapv :error))]
+      (if (seq errors)
+        (-> (res/response {:message (string/join "\n" errors)})
+            (res/status 400))
+        (handler request)))))
 
 (defn- attach-handler [handler openapi-meta]
-  (if (some? (:parameters openapi-meta))
-    (assoc openapi-meta
-           :handler
-           (fn [request]
-             (let [errors (->> (mapv (partial validate-param request) (:parameters openapi-meta))
-                               (filter #(:error %))
-                               (mapv :error))]
-               (if (seq errors)
-                 (-> (res/response errors)
-                     (res/status 400))
-                 (handler request))))
+  (cond-> openapi-meta
+    (some? (:parameters openapi-meta))
+    (assoc :middleware [[validation-wrapped-handler openapi-meta]]
            :responses (merge (:responses openapi-meta)
-                             {400 {:body [:vector
-                                          [:map
-                                           [:input [:map-of :keyword :any]]
-                                           [:errors [:or [:map-of :keyword [:vector :string]] [:vector :string]]]]]}}))
-    (assoc openapi-meta :handler handler)))
+                             (api/bad-request)))
+    true (assoc :handler handler)))
 
 (defn- merge-route-map [acc [method handler]]
   (->> (extract-openapi-meta handler)

--- a/src/abantu/util.clj
+++ b/src/abantu/util.clj
@@ -3,8 +3,8 @@
             [buddy.core.nonce :as nonce]
             [clojure.main :refer [demunge]]
             [malli.core :as m]
-            [malli.error :as me]
-            [malli.transform :as mt])
+            [malli.transform :as mt]
+            [clojure.string :as string])
   (:import (java.math BigInteger)
            (java.security MessageDigest)))
 
@@ -54,16 +54,53 @@
         hash-bytes (.digest digest bytes)]
     (format "%064x" (BigInteger. 1 hash-bytes))))
 
+(defn parse-type-from-schema [schema]
+  (cond
+    (keyword? schema)
+    (name schema)
+
+    (and (seq schema) (= (first schema) :vector))
+    (try
+      (str "Array[" (string/join " " (mapv name (rest schema))) "]")
+      (catch Exception _ "Array[]"))
+
+    (and (seq schema) (= (first schema) :map))
+    (try
+      (str "Object { " (reduce (fn [acc pair]
+                                 (str acc (string/join ": " (mapv name pair)) "; "))
+                               "" (rest [:map [:message :string] [:a :int]])) "}")
+      (catch Exception _ "Object {}"))))
+
+(defn append-humanised-error [acc error-map]
+  (let [path (string/join "." (mapv (fn [p]
+                                      (if (keyword? p)
+                                        (name p)
+                                        (str "[" p "]"))) (:path error-map)))
+        k (if (or (nil? path) (= path "")) "" (str path ": "))
+        value (:value error-map)
+        schema (m/form (:schema error-map))
+        error-type (cond
+                     (= (:type error-map) :malli.core/missing-key) :missing
+                     (= (:type error-map) :malli.core/invalid-type) :invalid
+                     :else :type-error)
+        expected (parse-type-from-schema schema)]
+    (cond
+      (= error-type :missing) (str acc "Missing required key: '" path "'\n")
+      (= error-type :invalid) (str acc k "Expected '" expected "', found '" value "'\n")
+      :else (str acc k "Expected '" expected "', found '" value "'\n"))))
+
+(defn humanise [{:keys [errors] :as _error}]
+  (reduce append-humanised-error "" errors))
+
 (defn validate
   [data schema]
   (let [transformed (m/decode schema data mt/string-transformer)
         success (m/validate schema transformed)]
     {:data (when success transformed)
      :success success
-     :error (when-not success {:input data
-                               :errors (->> transformed
-                                            (m/explain schema)
-                                            (me/humanize))})}))
+     :error (when-not success (->> transformed
+                                   (m/explain schema)
+                                   (humanise)))}))
 
 (defn format-rss-date
   "Takes a date as a string in RFC 1123 format and returns it in a format that meets ISO 8601 standards for SQLite.
@@ -83,5 +120,20 @@
   (validate business/post {:cheese "modulr"})
   (validate ctop/get {:mindate "2025-12-02" :maxdate "2025-12-02" :n "10" :contenttype 1 :top "post"} :query)
   (sha256 "1")
+
+  (validate {:message "yeet"
+             :b 1
+             :array {}
+             :test []
+             :units [{:name "cheese"}]}
+            [:map
+             [:message :string]
+             [:a :int]
+             [:b :string]
+             [:array [:vector :int]]
+             [:test [:map [:a :int]]]
+             [:units [:vector [:map
+                               [:name [:maybe :string]]
+                               [:description [:maybe :string]]]]]])
   ())
 

--- a/src/abantu/util.clj
+++ b/src/abantu/util.clj
@@ -55,17 +55,15 @@
     (format "%064x" (BigInteger. 1 hash-bytes))))
 
 (defn validate
-  ([handler data]
-   (validate handler data :body))
-  ([handler data schema-type]
-   (let [schema (get-in (metadata handler) [:parameters schema-type])
-         transformed (m/decode schema data mt/string-transformer)
-         success (m/validate schema transformed)]
-     {:data (when success transformed)
-      :success success
-      :error (when-not success (->> transformed
-                                    (m/explain schema)
-                                    (me/humanize)))})))
+  [data schema]
+  (let [transformed (m/decode schema data mt/string-transformer)
+        success (m/validate schema transformed)]
+    {:data (when success transformed)
+     :success success
+     :error (when-not success {:input data
+                               :errors (->> transformed
+                                            (m/explain schema)
+                                            (me/humanize))})}))
 
 (defn format-rss-date
   "Takes a date as a string in RFC 1123 format and returns it in a format that meets ISO 8601 standards for SQLite.

--- a/src/abantu/util.clj
+++ b/src/abantu/util.clj
@@ -68,7 +68,7 @@
     (try
       (str "Object { " (reduce (fn [acc pair]
                                  (str acc (string/join ": " (mapv name pair)) "; "))
-                               "" (rest [:map [:message :string] [:a :int]])) "}")
+                               "" (rest schema)) "}")
       (catch Exception _ "Object {}"))))
 
 (defn append-humanised-error [acc error-map]

--- a/src/abantu/util.clj
+++ b/src/abantu/util.clj
@@ -118,7 +118,6 @@
   (require '[abantu.routes.business :as business])
   (require '[abantu.routes.analytics.creator.top :as ctop])
   (validate business/post {:cheese "modulr"})
-  (validate ctop/get {:mindate "2025-12-02" :maxdate "2025-12-02" :n "10" :contenttype 1 :top "post"} :query)
   (sha256 "1")
 
   (validate {:message "yeet"

--- a/src/abantu/util.clj
+++ b/src/abantu/util.clj
@@ -78,6 +78,7 @@
                                         (str "[" p "]"))) (:path error-map)))
         k (if (or (nil? path) (= path "")) "" (str path ": "))
         value (:value error-map)
+        value (if (nil? value) "null" (:value error-map))
         schema (m/form (:schema error-map))
         error-type (cond
                      (= (:type error-map) :malli.core/missing-key) :missing


### PR DESCRIPTION
- Added middleware in the route utility to validate inputs from body, path or query params if schemas are present. Returns a 400 response if invalid, with error messages.
- If schemas are present, a 400 response is automatically added to the list of possible responses.

OpenAPI does not understand malli :any or :or, but below is the most accurate I can make it look.
<img width="1445" height="704" alt="image" src="https://github.com/user-attachments/assets/9c7c6337-29a2-4d14-9168-ab88f259d55b" />