### PR TITLE
Exercises API Update

### DIFF
--- a/.github/workflows/staging-deploy.yml
+++ b/.github/workflows/staging-deploy.yml
@@ -1,0 +1,29 @@
+name: Staging Deploy
+on:
+  push:
+    branches:
+      - dev
+jobs:
+  deploy:
+    name: Deploy to Staging
+    runs-on: ubuntu-latest
+    concurrency: deploy-group
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Connect to Tailscale
+        uses: tailscale/github-action@v4
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+          ping: mervstation.tail4f070.ts.net
+
+      - name: Execute remote SSH commands
+        run: |
+          ssh -o StrictHostKeyChecking=no merv@mervstation.tail4f070.ts.net '
+            cd /home/merv/Developer/abantu
+            git pull
+            ./build.sh
+            sudo /bin/systemctl restart abantu-api
+          '

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+export $(grep '.*' .env | xargs)
+
+echo "Starting compilation..."
+clojure -T:build uber

--- a/src/abantu/admins.clj
+++ b/src/abantu/admins.clj
@@ -14,7 +14,7 @@
   (try
     (-> (conf/read-value :admins-encrypted-path)
         (crypt/read-file-crypt (conf/read-value :supersecretkey)) 
-        (json/read-str))
+        (json/read-str {:key-fn keyword}))
     (catch Exception e
       (println (str "Couldn't read the admins file: " (.getMessage e)))
       [])))

--- a/src/abantu/db/master.clj
+++ b/src/abantu/db/master.clj
@@ -86,9 +86,9 @@
    [:instruction :text :not nil]
    [:question-content :text :not nil]
    [:audio :text]
-   [:answer-type :text [:check [:in :question-type ["freetext" "bubbles"]]]]
+   [:answer-type :text [:check [:in :answer-type ["freetext" "bubbles"]]]]
    [:options :text]
-   [:level :int]
+   [:level :int [:default 1]]
    (tables/foreign-key :unit-id :units :id)))
 
 (def answers

--- a/src/abantu/db/master.clj
+++ b/src/abantu/db/master.clj
@@ -83,8 +83,10 @@
    :exercises
    (tables/table-id)
    [:unit-id :integer :not nil]
-   [:question-type :text [:check [:in :question-type ["translation" "multiple-choice"]]]]
-   [:question :text :not nil]
+   [:instruction :text :not nil]
+   [:question-content :text :not nil]
+   [:audio :text]
+   [:answer-type :text [:check [:in :question-type ["freetext" "bubbles"]]]]
    [:options :text]
    [:level :int]
    (tables/foreign-key :unit-id :units :id)))
@@ -93,8 +95,9 @@
   (tables/create-table-sql
    :answers
    (tables/table-id)
+   [:exercise-id :int :not nil]
    [:text :text]
-   [:exercise-id :int]
+   [:audio :text]
    (tables/foreign-key :exercise-id :exercises :id)))
 
 (def practice-sessions

--- a/src/abantu/routes/api/units.clj
+++ b/src/abantu/routes/api/units.clj
@@ -84,7 +84,8 @@
                        :body api/UpdateExerciseParam)
    :responses (api/success api/GetExerciseResult)}
   [{:keys [ds path-params body] :as _request}]
-  (res/response (units/update-exercise! ds (assoc body :id (:id path-params)))))
+  (units/update-exercise! ds (assoc body :id (:id path-params)))
+  (res/response {:message "Successfully updated exercise"}))
 
 (defn delete-exercise
   {:summary "Delete an exercise by a given id"

--- a/src/abantu/routes/openapi.clj
+++ b/src/abantu/routes/openapi.clj
@@ -239,7 +239,7 @@
    [:unit-id :int]
    [:instruction :string]
    [:question-content :string]
-   [:answer-type :string]
+   [:answer-type [:enum "freetext" "bubbles"]]
    (sometimes :audio :string)
    [:options [:vector :string]]
    [:answers AnswerParams]])

--- a/src/abantu/routes/openapi.clj
+++ b/src/abantu/routes/openapi.clj
@@ -212,9 +212,11 @@
   GetUnitResult)
 
 (def AnswerParam
-  [:or
-   [:vector :string]
-   :string])
+  [:map
+   [:text [:or
+           [:vector :string]
+           :string]]
+   (sometimes :audio :string)])
 
 (def AnswerParams
   [:vector AnswerParam])

--- a/src/abantu/routes/openapi.clj
+++ b/src/abantu/routes/openapi.clj
@@ -212,7 +212,8 @@
   GetUnitResult)
 
 (def AnswerParam
-  [:or [:vector :string]
+  [:or
+   [:vector :string]
    :string])
 
 (def AnswerParams
@@ -220,8 +221,10 @@
 
 (def ExerciseParam
   [:map
-   [:question-type :string]
-   [:question :string]
+   [:instruction :string]
+   [:question-content :string]
+   (sometimes :audio :string)
+   [:answer-type [:enum "freetext" "bubbles"]]
    [:options [:vector :string]]
    (sometimes :answers AnswerParams)])
 
@@ -232,8 +235,10 @@
   [:map
    [:id :int]
    [:unit-id :int]
-   [:question-type :string]
-   [:question :string]
+   [:instruction :string]
+   [:question-content :string]
+   [:answer-type :string]
+   (sometimes :audio :string)
    [:options [:vector :string]]
    [:answers AnswerParams]])
 
@@ -243,10 +248,12 @@
 (def UpdateExerciseParam
   [:map
    (sometimes :unit-id :int)
-   (sometimes :question-type :string)
-   (sometimes :question :string)
+   (sometimes :instruction :string)
+   (sometimes :question-content :string)
+   (sometimes :audio :string)
+   (sometimes :answer-type [:enum "freetext" "bubbles"])
    (sometimes :options [:vector :string])
-   (sometimes :answers  AnswerParams)])
+   (sometimes :answers AnswerParams)])
 
 (def UpdateUnitParam
   (-> GetUnitResult

--- a/src/abantu/services/units.clj
+++ b/src/abantu/services/units.clj
@@ -129,8 +129,9 @@
     (db/insert! ds {:tname :answers
                     :data (mapv #(assoc % :exercise-id id) answers)
                     :ret :*}))
-  (db/update! ds {:tname :exercise
-                  :data (dissoc exercise :answers)}))
+  (db/update! ds {:tname :exercises
+                  :data (dissoc exercise :answers)
+                  :where [:= :id id]}))
 
 (defn delete-exercise [ds id]
   (let [{:keys [id answers] :as exercise} (get-exercise ds id)]

--- a/src/abantu/services/units.clj
+++ b/src/abantu/services/units.clj
@@ -1,8 +1,8 @@
 (ns abantu.services.units
   (:require [abantu.db.interface :as db]
-            [malli.util :as mu]
-            [clojure.string :as str]))
-
+            [clojure.string :as str]
+            [abantu.db.util :as db.util]
+            [abantu.db.honey :as hon]))
 
 (defn- process-options [exercise]
   (update-in exercise
@@ -10,23 +10,23 @@
              #(-> (clojure.string/split % #";;")
                   (vec))))
 
-(defn- add-answers [ds {:keys [id question-type] :as exercise}]
+(defn- add-answers [ds {:keys [id answer-type] :as exercise}]
   (let [answers (db/find ds {:tname :answers
-                                        :where [:= :exercise-id id]
-                                        :ret :*})
-        answers (if (= question-type "multiple-choice")
-                  (mapv :text answers)
-                  (mapv #(str/split (:text %) #";;") answers))]
-  (assoc exercise :answers answers)))
+                             :where [:= :exercise-id id]
+                             :ret :*})
+        answers (if (= answer-type "bubbles")
+                  (mapv #(assoc % :text (str/split (:text %) #";;")) answers)
+                  answers)]
+    (assoc exercise :answers answers)))
 
 (defn get-exercises-for-unit
   "Get all exercises with answers for a given unit-id"
   [ds id]
-    (->> (db/find ds {:tname :exercises
-                      :where [:= :unit-id id]
-                      :ret :*})
-         (mapv (comp process-options
-                     (partial add-answers ds)))))
+  (->> (db/find ds {:tname :exercises
+                    :where [:= :unit-id id]
+                    :ret :*})
+       (mapv (comp process-options
+                   (partial add-answers ds)))))
 
 (defn get-unit
   "get a unit with all exercises for a given unit-id"
@@ -43,8 +43,8 @@
   "Get all units with exercises for a given course-id"
   [ds course-id]
   (->> (db/find ds {:tname :units
-               :where [:= :course-id course-id]
-               :ret :*})
+                    :where [:= :course-id course-id]
+                    :ret :*})
        (mapv #(assoc % :exercises
                      (get-exercises-for-unit ds (:id %))))))
 
@@ -56,28 +56,27 @@
                            :ret :*})]
     (mapv (partial add-exercises-to-unit ds) units)))
 
-(defn get-question-type [ds exercise-id]
+(defn get-answer-type [ds exercise-id]
   (->>
    (db/find ds {:tname :exercises
                 :where [:= :id exercise-id]
                 :ret :1})
-   (:question-type)))
+   (:answer-type)))
 
 (defn get-answers-for-exercise [ds exercise-id]
-  (let [question-type (get-question-type ds exercise-id)
+  (let [answer-type (get-answer-type ds exercise-id)
         answers (db/find ds {:tname :answers
                              :where [:= :exercise-id exercise-id]
                              :ret :*})]
     (->> answers
-         (mapv (comp #(if (= question-type "translation")
-                        (str/split % #";;")
-                        %)
-                     :text)))))
+         (mapv #(if (= answer-type "bubbles")
+                  (assoc % :text (str/split (:text %) #";;"))
+                  %)))))
 
 (defn save-answers-for-exercise! [ds exercise-id answer-type answers]
-  (->> (mapv (comp #(assoc {} :text % :exercise-id exercise-id)
+  (->> (mapv (comp #(merge {:exercise-id exercise-id} %)
                    #(if (= answer-type "bubbles")
-                      (str/join ";;" %)
+                      (assoc % :text (str/join ";;" (:text %)))
                       %))
              answers)
        (assoc {:tname :answers :ret :*} :data)
@@ -101,8 +100,8 @@
 
 (defn save-unit! [ds {:keys [exercises] :as unit}]
   (let [{:keys [id] :as result} (db/insert! ds {:tname :units
-                               :data (dissoc unit :exercises)
-                               :ret :1})]
+                                                :data (dissoc unit :exercises)
+                                                :ret :1})]
     (->> (when (seq exercises)
            (save-exercises! ds (mapv #(assoc % :unit-id id) exercises)))
          (assoc result :exercises))))
@@ -144,16 +143,15 @@
                       :where [:= :id id]
                       :ret :1}))))
 
-
 (defn delete-unit! [ds id]
   (let [unit (get-unit ds id)
         exercises (:exercises unit)]
     (when (seq exercises)
       (run! (partial delete-exercise ds) (mapv :id exercises)))
     (when (some? unit)
-    (db/delete! ds {:tname :units
-                    :where [:= :id id]
-                    :ret :1}))
+      (db/delete! ds {:tname :units
+                      :where [:= :id id]
+                      :ret :1}))
     (some? unit)))
 
 (comment
@@ -165,10 +163,10 @@
                                  :question "isiXhosa"
                                  :options "Xhosa,Xhosas,a,It's"
                                  :answers [{:text "Xhosa"}]}]}])
-  
+
   (db/find ds {:tname :exercises
                :ret :*})
-  
+
   (get-exercises-for-unit ds 1)
 
   (def test-insert (->> (get-exercises-for-unit ds 1)
@@ -185,19 +183,18 @@
                                 :options ["umbuzo" "imibuzo" "yintoni" "ntoni" "untoni"]
                                 :answers [["yintoni" "umbuzo"] ["untoni" "umbuzo"]]
                                 :level 1)))
-  
+
   (get-all-units ds)
 
   (db/find ds {:tname :answers
                :where [:= :exercise-id nil]
                :ret :*})
   (db/delete! ds {:tname :units
-                 :where [:= :id 1]
-                 :ret :*})
+                  :where [:= :id 1]
+                  :ret :*})
 
   (db/delete! ds {:tname :units
-                 :where [:= :creator-id nil] 
-                 :ret :*})
+                  :where [:= :creator-id nil]
+                  :ret :*})
 
-  ()
-  )
+  ())

--- a/src/abantu/services/units.clj
+++ b/src/abantu/services/units.clj
@@ -74,24 +74,23 @@
                         %)
                      :text)))))
 
-(defn save-answers-for-exercise! [ds exercise-id question-type answers]
+(defn save-answers-for-exercise! [ds exercise-id answer-type answers]
   (->> (mapv (comp #(assoc {} :text % :exercise-id exercise-id)
-                   #(if (= question-type "translation")
+                   #(if (= answer-type "bubbles")
                       (str/join ";;" %)
                       %))
              answers)
        (assoc {:tname :answers :ret :*} :data)
        (db/insert! ds)))
 
-
-(defn save-exercise! [ds {:keys [options answers question-type] :as exercise}]
+(defn save-exercise! [ds {:keys [options answers answer-type] :as exercise}]
   (let [{:keys [id] :as result}
         (db/insert! ds {:tname :exercises
                         :data (-> (dissoc exercise :answers)
                                   (assoc :options (str/join ";;" options)))
                         :ret :1})]
     (when (seq answers)
-      (save-answers-for-exercise! ds id question-type answers))
+      (save-answers-for-exercise! ds id answer-type answers))
     (assoc result
            :answers (get-answers-for-exercise ds id)
            :options options)))


### PR DESCRIPTION
This closes #21 

- Updated db schema to allow storing the following:
instruction
question content
answer type, freetext and bubbles (as enum, extendable)
options as delimited string
audio as optional url string

- Updated parameters on API interface to match the data required for the database
- Updated return schemas on API interface
- Updated implementation to support interface and store optional audio urls

Added GitHub workflow for deploying to mervstation (hereinafter 'staging') on merge to dev